### PR TITLE
Add UnityAdsManager to skipProperties

### DIFF
--- a/UniTAS/Patcher/Implementations/ExternPropertyReset.cs
+++ b/UniTAS/Patcher/Implementations/ExternPropertyReset.cs
@@ -123,6 +123,9 @@ public class ExternPropertyReset(ILogger logger, IPatchReverseInvoker patchRever
     [
         // crashes game
         "UnityEngine.AssetBundleLoadingCache.maxBlocksPerFile",
+        "UnityEngine.Advertisements.UnityAdsManager.enabled",
+        "UnityEngine.Advertisements.UnityAdsManager.initializeOnStartup",
+        "UnityEngine.Advertisements.UnityAdsManager.testMode",
         "UnityEngine.Advertisements.UnityAdsSettings.enabled",
         "UnityEngine.Advertisements.UnityAdsSettings.initializeOnStartup",
         "UnityEngine.Advertisements.UnityAdsSettings.testMode",


### PR DESCRIPTION
Unity 5 uses UnityAdsManager instead of UnityAdsSettings in newer versions, so added this as a property to skip so games with this unity version doesn't crash on startup (like Emi with memory access violation).