### PR TITLE
Add localization framework

### DIFF
--- a/UniTAS/Patcher/Implementations/Customization/Config.Section.cs
+++ b/UniTAS/Patcher/Implementations/Customization/Config.Section.cs
@@ -21,5 +21,11 @@ public partial class Config
             public const string Address = "Address";
             public const string Port = "Port";
         }
+
+        public static class Localization
+        {
+            public const string SectionName = $"{nameof(Localization)}";
+            public const string Locale = "Locale";
+        }
     }
 }

--- a/UniTAS/Patcher/Implementations/GUI/Windows/ToolBar.cs
+++ b/UniTAS/Patcher/Implementations/GUI/Windows/ToolBar.cs
@@ -6,6 +6,7 @@ using UniTAS.Patcher.Models.UnitySafeWrappers;
 using UniTAS.Patcher.Services;
 using UniTAS.Patcher.Services.Customization;
 using UniTAS.Patcher.Services.GUI;
+using UniTAS.Patcher.Services.Localization;
 using UniTAS.Patcher.Services.UnityEvents;
 using UniTAS.Patcher.Services.UnitySafeWrappers.Wrappers;
 using UniTAS.Patcher.Utils;
@@ -20,6 +21,7 @@ public class ToolBar : IToolBar, IActualCursorState
 {
     private readonly IWindowFactory _windowFactory;
     private readonly ICursorWrapper _cursorWrapper;
+    private readonly ILocalization _localizationHandler;
 
     private readonly GUIStyle _buttonStyle;
     private readonly Texture2D _buttonNormal = new(1, 1);
@@ -68,10 +70,11 @@ public class ToolBar : IToolBar, IActualCursorState
 
     public ToolBar(IWindowFactory windowFactory, IBinds binds, IGUIComponentFactory guiComponentFactory,
         IObjectTrackerManager objectTrackerManager, IUpdateEvents updateEvents, ICursorWrapper cursorWrapper,
-        IGameRestart gameRestart)
+        IGameRestart gameRestart, ILocalization localizationHandler)
     {
         _windowFactory = windowFactory;
         _cursorWrapper = cursorWrapper;
+        _localizationHandler = localizationHandler;
         gameRestart.OnGameRestart += OnGameRestart;
         _dropdownList = guiComponentFactory.CreateComponent<IDropdownList>();
 
@@ -151,14 +154,14 @@ public class ToolBar : IToolBar, IActualCursorState
 
         GUILayout.FlexibleSpace();
 
-        if (GUILayout.Button("Movie", _buttonStyle, GUIUtils.EmptyOptions))
+        if (GUILayout.Button(_localizationHandler.Get("Movie"), _buttonStyle, GUIUtils.EmptyOptions))
         {
             _windowFactory.Create<MoviePlayWindow>().Show = true;
         }
 
         GUILayout.FlexibleSpace();
 
-        if (GUILayout.Button("View", _buttonStyle, GUIUtils.EmptyOptions))
+        if (GUILayout.Button(_localizationHandler.Get("View"), _buttonStyle, GUIUtils.EmptyOptions))
         {
             _currentDropDown = DropDownSection.View;
         }
@@ -171,7 +174,7 @@ public class ToolBar : IToolBar, IActualCursorState
 
         GUILayout.FlexibleSpace();
 
-        if (GUILayout.Button("Windows", _buttonStyle, GUIUtils.EmptyOptions))
+        if (GUILayout.Button(_localizationHandler.Get("Windows"), _buttonStyle, GUIUtils.EmptyOptions))
         {
             _currentDropDown = DropDownSection.Windows;
         }
@@ -183,7 +186,7 @@ public class ToolBar : IToolBar, IActualCursorState
 
         GUILayout.FlexibleSpace();
 
-        if (GUILayout.Button("Settings", _buttonStyle, GUIUtils.EmptyOptions))
+        if (GUILayout.Button(_localizationHandler.Get("Settings"), _buttonStyle, GUIUtils.EmptyOptions))
         {
             _currentDropDown = DropDownSection.Settings;
         }

--- a/UniTAS/Patcher/Implementations/Localization/Localization.cs
+++ b/UniTAS/Patcher/Implementations/Localization/Localization.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using UniTAS.Patcher.Implementations.Customization;
+using UniTAS.Patcher.Interfaces.DependencyInjection;
+using UniTAS.Patcher.Models.DependencyInjection;
+using UniTAS.Patcher.Services;
+using UniTAS.Patcher.Services.Localization;
+using UniTAS.Patcher.Services.Logging;
+using UniTAS.Patcher.Utils;
+
+[Singleton(RegisterPriority.ToolBar)]
+[ForceInstantiate]
+public class Localization : ILocalization
+{
+    public Dictionary<string, Dictionary<string, string>> Tables { get; set; }
+    public string Locale { get; set; } = "en";
+
+    private readonly IConfig _config;
+    private readonly ILogger _logger;
+
+    public Localization(IConfig config, ILogger logger)
+    {
+        _config = config;
+        _logger = logger;
+        try
+        {
+            Locale = _config.TryGetBackendEntry(Config.Sections.Localization.Locale, out string locale) ? locale : "en";
+            Load(Locale, UniTASPaths.Localization);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to load localization file: {ex.Message}. Keys will be displayed.\r\n{ex.StackTrace}");
+            Tables = new Dictionary<string, Dictionary<string, string>>();
+        }
+    }
+
+    public void Load(string locale, string path)
+    {
+        Locale = locale;
+        Tables = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(File.ReadAllText(path));
+    }
+
+    public string Get(string key)
+    {
+        if (Tables.TryGetValue(Locale, out var table) && table.TryGetValue(key, out var value))
+            return value;
+        if (Tables["en"].TryGetValue(key, out var enValue))
+            return enValue;
+        return $"#{key}#";
+    }
+}

--- a/UniTAS/Patcher/RuntimeResources/Resources/localestrings.json
+++ b/UniTAS/Patcher/RuntimeResources/Resources/localestrings.json
@@ -1,0 +1,8 @@
+{
+  "en": {
+    "Movie": "Movie",
+    "Windows": "Windows",
+    "View": "View",
+    "Settings": "Settings"
+  }
+}

--- a/UniTAS/Patcher/Services/Localization/ILocalization.cs
+++ b/UniTAS/Patcher/Services/Localization/ILocalization.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace UniTAS.Patcher.Services.Localization;
+
+public interface ILocalization
+{
+    Dictionary<string, Dictionary<string, string>> Tables { get; set; }
+    string Locale { get; set; }
+    void Load(string locale, string path);
+    string Get(string key);
+}

--- a/UniTAS/Patcher/Utils/Paths.cs
+++ b/UniTAS/Patcher/Utils/Paths.cs
@@ -23,4 +23,5 @@ public static class UniTASPaths
     public const string BepInExConfigFileName = "UniTAS.cfg";
     public static string ConfigBackend { get; } = Path.Combine(UniTASBase, BackendConfigFileName);
     private const string BackendConfigFileName = "save.dat";
+    public static string Localization { get; } = Path.Combine(Resources, "localestrings.json");
 }


### PR DESCRIPTION
This PR is a small proof of concept of localization systems. On account of the potential userbase of this project, especially as future milestones include more GUI additions, it would be a decent thing to consider going forward. This only adds a barebones system that could easily be expanded on with further data and references to localization keys.

Of course this would need maintaining by translators, so as such, this only affects 4 strings in the F1 menu.

The `localestrings.json` is stored in the Resources directory alongside other the assets. This also introduces a .cfg entry that allows for setting the locale used, but if one isn't specified, it will default to `en`.

Missing entries default to en, while missing files/entries across all locales will return the localization key used.

**This may also require an adjustment of its loading priority in future.**